### PR TITLE
Update RawHtmlFieldInput.js

### DIFF
--- a/src/RawHtmlFieldInput.js
+++ b/src/RawHtmlFieldInput.js
@@ -80,7 +80,7 @@ class RawHtmlFieldInput extends React.Component {
     } else if (input.type === 'checkbox' || input.type === 'radio') {
       const boxes = this.inputs;
       value = boxes.filter(box => box.checked).map(box => box.value);
-    } else if (input.tagName === 'SELECT') {
+    } else if (input.tagName === 'select') {
       value = input.options[input.selectedIndex].value;
     } else {
       value = input.value;


### PR DESCRIPTION
fix case for input tagname comparison?

i've been running into an issue where wagtail ChoiceBlocks (rendered as <select>'s) with default values are showing a value of `null` in my react devtools. I think this comparison is the cause, but not totally sure.